### PR TITLE
Fix never ending processing of inline links

### DIFF
--- a/lib/typrocessor/ignores/markdown.rb
+++ b/lib/typrocessor/ignores/markdown.rb
@@ -9,6 +9,6 @@ class Typrocessor::Ignore
     ignore 'inline code', /(`{1,2}).*?\1/
     ignore 'strong', /\*\*|__/
 
-    ignore 'urls', /\b((?:[a-zA-Z][\w-]+:(?:\/{1,3}|[a-zA-Z0-9%])|www\d{0,3}[.]|[a-zA-Z0-9.\-]+[.][a-zA-Z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?\u00AB\u00BB\u201C\u201D\u2018\u2019]))/
+    ignore 'urls', /\bhttp(s?)[^\s\)\]]*/ # more complex regex induces VERY long processing times
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,5 @@ RSpec.configure do |config|
   # config.formatter = :documentation # :progress, :html, :textmate
 
   config.order = :random
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,5 +11,4 @@ RSpec.configure do |config|
   # config.formatter = :documentation # :progress, :html, :textmate
 
   config.order = :random
-
 end

--- a/spec/typrocessor/ignores/markdown_spec.rb
+++ b/spec/typrocessor/ignores/markdown_spec.rb
@@ -20,10 +20,10 @@ describe 'Typrocessor::Ignore::Markdown' do
     expect(processor.process('![foo] (http://foo.com/foo.jpg "foo")')).to eq('![bar] (http://foo.com/foo.jpg "foo")')
   end
 
-  it 'preserves inline links' do
+  it 'preserves inline links', focus: true do
     expect(processor.process('[foo](http://foo.com/foo.jpg)')).to eq('[bar](http://foo.com/foo.jpg)')
     expect(processor.process('[foo] (http://foo.com/foo.jpg)')).to eq('[bar] (http://foo.com/foo.jpg)')
-
+    expect(processor.process('[https://www.foofoofoofoo.fr/](https://www.foofoofoofoo.fr/)')).to eq('[https://www.foofoofoofoo.fr/](https://www.foofoofoofoo.fr/)')
     expect(processor.process('[%(foo) foo de foo foo] (/foo/link-with-hyphens)')).to eq('[%(bar) bar de bar bar] (/foo/link-with-hyphens)')
   end
 


### PR DESCRIPTION
When the label is itself an URL, processing time is exponential, and can be very very long very soon.